### PR TITLE
fix: throw an error if the status code is a faulty one and stop the stream if a 204 is received

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,13 +114,15 @@ impl Stream for EventsourceRequestBuilder {
                             }
 
                             // FIXME: "HTTP 200 OK responses that have a Content-Type specifying an unsupported type, or that have no Content-Type at all, must cause the user agent to fail the connection."
-                            // https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model 
+                            // https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model
+
+                            this.next_response.take();
 
                             let event_stream = Box::pin(_res.bytes_stream().eventsource());
                             this.cur_stream.replace(event_stream);
                         }
                         Err(err) => {
-                            return Poll::Ready(Some(Err(EventStreamError::Transport(err))))
+                            return Poll::Ready(Some(Err(EventStreamError::Transport(err))));
                         }
                     }
                 }


### PR DESCRIPTION
Partial fix for https://github.com/jpopesculian/reqwest-eventsource/issues/7.

A better fix would be to only allow 200, as stated by the spec, but this isn't possible without a BC break: it's not possible to create a new `reqwest::Error` for the other status codes.
We have a similar problem with the Content-Type: it must be set by the server to `text/event-stream`, and we should throw an error if it's not the case, but there is currently no corresponding `reqwest::Error`.

A better solution (at the cost of a BC break), is to introduce our custom error type (using `thiserror` or a similar crate). I suggest merging this patch as a quick fix for the current version, and to start working on a better implem in a new major version.