### PR TITLE
fix(check_response): fallback to content-type without parameters

### DIFF
--- a/src/event_source.rs
+++ b/src/event_source.rs
@@ -138,11 +138,14 @@ fn check_response(response: Response) -> Result<Response, Error> {
             s.parse::<mime::Mime>()
                 .map_err(|_| (()))
                 // Fallback to content type without parameters.
-                .or_else(|_|  match s.contains(";") {
-                        true => s.split(';').next().map(|s| s.parse::<mime::Mime>().map_err(|_| (()))).unwrap(),
-                        false => Err(())
-                    }
-                )   
+                .or_else(|_| match s.contains(";") {
+                    true => s
+                        .split(';')
+                        .next()
+                        .map(|s| s.parse::<mime::Mime>().map_err(|_| (())))
+                        .unwrap(),
+                    false => Err(()),
+                })
         })
         .map(|mime_type| {
             matches!(

--- a/src/event_source.rs
+++ b/src/event_source.rs
@@ -134,6 +134,7 @@ fn check_response(response: Response) -> Result<Response, Error> {
     if content_type
         .to_str()
         .map_err(|_| ())
+        .and_then(|s| s.split(';').next().ok_or(()))
         .and_then(|s| s.parse::<mime::Mime>().map_err(|_| ()))
         .map(|mime_type| {
             matches!(


### PR DESCRIPTION
Currently, `reqwest_eventsource` cannot be used for endpoints that return `content-type: application/json; charset=UTF-8"`, due to the following error: `Invalid header value: "application/json; charset=UTF-8"`

This is because the full header value is passed to `mime::parse()`, and `mime` only supports "application/json":

https://github.com/hyperium/mime/blob/938484de95445a2af931515d2b7252612c575da7/mime-parse/src/constants.rs#L461