### PR TITLE
minor: Expose `MessageEvent` used in `Event`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,5 +29,5 @@ mod reqwest_ext;
 pub mod retry;
 
 pub use error::{CannotCloneRequestError, Error};
-pub use event_source::{Event, EventSource, ReadyState};
+pub use event_source::{Event, EventSource, MessageEvent, ReadyState};
 pub use reqwest_ext::RequestBuilderExt;


### PR DESCRIPTION
This is useful when trying to reference the `MessageEvent` type while unpacking an `Event`.