### PR TITLE
expose feature wasm-bindgen from futures-timer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures-retry = "0.6"
 pin-utils = "0.1"
 rocket = "0.5.0"
+
+[features]
+default = []
+wasm-bindgen = ["futures-timer/wasm-bindgen"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+use std::env::var;
+
+fn main() {
+    if var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() == "wasm32"
+        && var("CARGO_CFG_TARGET_VENDOR").unwrap_or_default() == "unknown"
+        && var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == ""
+        && var("CARGO_FEATURE_WASM_BINDGEN").is_err()
+    {
+        println!("cargo:warning=Compiling for wasm32-unknown-unknown but without wasm-bindgen feature enabled. Trying to access futures-timer functionality will cause panics.");
+    }
+}


### PR DESCRIPTION
...and add warning when not using wasm-bindgen feature on wasm32-unknown-unknown target.

By exposing the `wasm-bindgen` feature, users can opt-in to using the wasm32-compatible time implementation of futures-timer.

fixes #27 