### PR TITLE
chore: Upgrade `reqwest` to support `>=0.12.0, <0.14.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["web-programming::http-client", "no-std", "parsing", "asynchronous
 
 [dependencies]
 eventsource-stream = "0.2.3"
-reqwest = { version = "0.12.0", default-features = false, features = ["stream"] }
+reqwest = { version = ">=0.12.0, <0.14.0", default-features = false, features = ["stream"] }
 futures-core = "0.3.5"
 pin-project-lite = "0.2.8"
 nom = "7.1.0"


### PR DESCRIPTION
Fixes #36